### PR TITLE
Fix Home Assistant 2026.3 compatibility

### DIFF
--- a/custom_components/dell_printer/__init__.py
+++ b/custom_components/dell_printer/__init__.py
@@ -46,25 +46,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    # setup sensors
-    for p in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, p)
-        )
-    # hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    # setup platforms
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    
-    for p in PLATFORMS:
-        await hass.config_entries.async_forward_entry_unload(entry, p)
 
-    hass.data[DOMAIN].pop(entry.entry_id)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
 
-    return True
+    return unload_ok
 
 
 class DellDataUpdateCoordinator(DataUpdateCoordinator):

--- a/custom_components/dell_printer/binary_sensor.py
+++ b/custom_components/dell_printer/binary_sensor.py
@@ -2,8 +2,8 @@ from typing import Callable, Any, Dict
 from custom_components.dell_printer import DellDataUpdateCoordinator, DellPrinterEntity
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
 import logging
@@ -13,7 +13,7 @@ from .const import *
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry, async_add_entities: Callable):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: Callable):
     """Setup binary sensor entity."""
 
     _LOGGER.debug(f"async_setup_entry called")

--- a/custom_components/dell_printer/sensor.py
+++ b/custom_components/dell_printer/sensor.py
@@ -2,8 +2,8 @@ from typing import Callable, Any, Dict
 from custom_components.dell_printer import DellDataUpdateCoordinator, DellPrinterEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
 import logging
@@ -13,7 +13,7 @@ from .const import *
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry, async_add_entities: Callable):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: Callable):
     """Setup sensor entity."""
 
     _LOGGER.debug(f"async_setup_entry called")


### PR DESCRIPTION
Fixed platform setup and typing imports to resolve startup failures on HA 2026.3.

 - Migrate config entry forwarding to current APIs:
    - use async_forward_entry_setups(entry, PLATFORMS)
    - use async_unload_platforms(entry, PLATFORMS)
    - only remove stored coordinator data after successful unload
 - Replace removed HomeAssistantType imports with HomeAssistant from homeassistant.core in platform modules (sensor.py, binary_sensor.py)